### PR TITLE
[Feature] Autoplay Video in README File

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,7 @@ npx salt-app-kickstart@latest
 
 ## 🎥 Video Demonstration
 
-[![](/gifbig.gif)](https://drive.google.com/file/d/1JIBCPyL2K3Ta3AOMTqt7BuqHjlnxS7m3/view?usp=sharing)
+[![](/video-thumbnail.gif)](https://drive.google.com/file/d/1JIBCPyL2K3Ta3AOMTqt7BuqHjlnxS7m3/view?usp=sharing)
 
 ## 🌟 Why Salt App Kickstart?
 

--- a/readme.md
+++ b/readme.md
@@ -33,9 +33,10 @@ npx salt-app-kickstart@latest
 
 ## 🎥 Video Demonstration
 <div align="center">
-<a href="https://drive.google.com/file/d/1JIBCPyL2K3Ta3AOMTqt7BuqHjlnxS7m3/view?usp=sharing" controls autoplay>
-  <img src="/video-thumbnail.png" alt="Demonstration of the package" width="600"/>
-</a>
+<video width="600" controls autoplay loop muted>
+  <source src="https://drive.google.com/uc?id=1JIBCPyL2K3Ta3AOMTqt7BuqHjlnxS7m3" type="video/mp4">
+  Your browser does not support the video tag.
+</video>
 </div>
 
 ## 🌟 Why Salt App Kickstart?

--- a/readme.md
+++ b/readme.md
@@ -32,7 +32,15 @@ npx salt-app-kickstart@latest
 - Finally, your app will launch on `localhost`, allowing you to start coding immediately!
 
 ## 🎥 Video Demonstration
-<div align="center"> <video width="600" controls autoplay muted> <source src="https://drive.google.com/uc?id=1JIBCPyL2K3Ta3AOMTqt7BuqHjlnxS7m3" type="video/mp4"> Your browser does not support the video tag. </video> </div>
+<div align="center">
+  <iframe 
+    src="https://drive.google.com/file/d/1JIBCPyL2K3Ta3AOMTqt7BuqHjlnxS7m3/preview" 
+    width="600" 
+    height="400" 
+    allow="autoplay" 
+    frameborder="0">
+  </iframe>
+</div>
 
 ## 🌟 Why Salt App Kickstart?
 

--- a/readme.md
+++ b/readme.md
@@ -32,12 +32,7 @@ npx salt-app-kickstart@latest
 - Finally, your app will launch on `localhost`, allowing you to start coding immediately!
 
 ## 🎥 Video Demonstration
-<div align="center">
-<video width="600" controls autoplay loop muted>
-  <source src="https://drive.google.com/uc?id=1JIBCPyL2K3Ta3AOMTqt7BuqHjlnxS7m3" type="video/mp4">
-  Your browser does not support the video tag.
-</video>
-</div>
+<div align="center"> <video width="600" controls autoplay muted> <source src="https://drive.google.com/uc?id=1JIBCPyL2K3Ta3AOMTqt7BuqHjlnxS7m3" type="video/mp4"> Your browser does not support the video tag. </video> </div>
 
 ## 🌟 Why Salt App Kickstart?
 

--- a/readme.md
+++ b/readme.md
@@ -32,12 +32,8 @@ npx salt-app-kickstart@latest
 - Finally, your app will launch on `localhost`, allowing you to start coding immediately!
 
 ## 🎥 Video Demonstration
-<div align="center">
-  <video src="https://github.com/Devamani11D/salt-app-kickstart/assets/video/demo.mp4" controls="controls" muted="muted" playsinline="playsinline" width="600" autoplay>
-  </video>
-</div>
 
-> 💡 Can't see the video? [Watch it on Google Drive](https://drive.google.com/file/d/1JIBCPyL2K3Ta3AOMTqt7BuqHjlnxS7m3/view?usp=sharing)
+[![Demo Video](/gifbig.gif)](https://drive.google.com/file/d/1JIBCPyL2K3Ta3AOMTqt7BuqHjlnxS7m3/view?usp=sharing)
 
 ## 🌟 Why Salt App Kickstart?
 

--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,7 @@ npx salt-app-kickstart@latest
 
 ## 🎥 Video Demonstration
 
-[![Demo Video](/gifbig.gif)](https://drive.google.com/file/d/1JIBCPyL2K3Ta3AOMTqt7BuqHjlnxS7m3/view?usp=sharing)
+[![](/gifbig.gif)](https://drive.google.com/file/d/1JIBCPyL2K3Ta3AOMTqt7BuqHjlnxS7m3/view?usp=sharing)
 
 ## 🌟 Why Salt App Kickstart?
 

--- a/readme.md
+++ b/readme.md
@@ -33,14 +33,11 @@ npx salt-app-kickstart@latest
 
 ## 🎥 Video Demonstration
 <div align="center">
-  <iframe 
-    src="https://drive.google.com/file/d/1JIBCPyL2K3Ta3AOMTqt7BuqHjlnxS7m3/preview" 
-    width="600" 
-    height="400" 
-    allow="autoplay" 
-    frameborder="0">
-  </iframe>
+  <video src="https://github.com/Devamani11D/salt-app-kickstart/assets/video/demo.mp4" controls="controls" muted="muted" playsinline="playsinline" width="600" autoplay>
+  </video>
 </div>
+
+> 💡 Can't see the video? [Watch it on Google Drive](https://drive.google.com/file/d/1JIBCPyL2K3Ta3AOMTqt7BuqHjlnxS7m3/view?usp=sharing)
 
 ## 🌟 Why Salt App Kickstart?
 


### PR DESCRIPTION
## What does this PR do?

This PR addresses the issue of requiring users or contributors to click on a video thumbnail to play the video in the README file. The change allows for a GIF preview of the video to be displayed, which can be clicked to link to the full video hosted on Google Drive. Due to GitHub's limitations, full videos cannot be embedded directly; therefore, this approach provides a smooth user experience by showing an engaging GIF while linking to the complete content.

Fixes #73

![image](https://github.com/user-attachments/assets/4a924482-d6b8-47b6-9c6f-95f800c08e28)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How should this be tested?

To verify the changes made in this PR, follow these steps:

- Open the README file and ensure that the GIF is displayed properly.
- Click on the GIF and verify that it opens the full video in a new tab on Google Drive.

- [x] Test A: Verify that the GIF links to the correct video.
- [x] Test B: Ensure that the GIF plays smoothly without performance issues.

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.