### PR TITLE
added back to top button in readme 

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -244,3 +244,9 @@ This project is licensed under the **MIT License**. For more details, check the 
 If you have any questions or suggestions, feel free to [reach out](mailto:duddekuntadevamani@gmail.com). We’re here to help you build awesome apps with Salt!
 
 Made with ❤️ by [Duddekunta Devamani](https://github.com/Devamani11D).
+
+<div align="center">
+    <a href="#top">
+        <img src="https://img.shields.io/badge/Back%20to%20Top-000000?style=for-the-badge&logo=github&logoColor=white" alt="Back to Top">
+    </a>
+</div>


### PR DESCRIPTION
## What does this PR do?

A bottom-to-top scroll-up button has been added to the README for improved navigation. This button enhances user experience by allowing easy access to the top of the page from anywhere in the document.

Fixes #79 

## Screenshots:
![image](https://github.com/user-attachments/assets/59b67d56-9b31-4fc6-a0d6-e0f0e4db2c7b)


## Type of change
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

## How should this be tested?

1. **Scroll Test**:
   - Scroll down the page to ensure the "Back to Top" button appears when reaching a specified scroll depth.
   - Click the button to verify it smoothly scrolls the page back to the top.
   
2. **Responsive Test**:
   - Test the "Back to Top" button on different screen sizes to confirm it appears correctly on mobile, tablet, and desktop views.

3. **Visibility Test**:
   - Confirm that the button only appears after scrolling down and hides when at the top of the page.

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

@Devamani11D Please review and merge my code under gssoc-ext level1